### PR TITLE
Implement IPC protocol, server skeleton, and scanner worker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,13 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake libboost-system-dev libboost-thread-dev
-
+          sudo apt-get install -y build-essential cmake libboost-system-dev libboost-thread-dev libsqlite3-dev
       # ---------------- macOS ----------------
       - name: Install Boost (macOS)
         if: runner.os == 'macOS'
         run: |
           brew update
-          brew install boost cmake
+          brew install boost cmake sqlite
 
       # ---------------- Windows ----------------
       - name: Install Boost (Windows)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,23 @@ jobs:
       - name: Setup CMake
         uses: jwlawson/actions-setup-cmake@v1
 
+      - name: Install Boost (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libboost-system-dev libboost-thread-dev
+
+      - name: Install Boost (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install boost
+
+      - name: Install Boost (Windows)
+        if: runner.os == 'Windows'
+        uses: egor-tensin/setup-boost@v1
+        with:
+          boost_version: 1.83.0
+
       - name: Configure
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
 
@@ -27,4 +44,3 @@ jobs:
       - name: Run App
         run: ./build/bin/medialode-app
         if: runner.os != 'Windows'
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
         run: |
           brew update
           brew install boost sqlite
+          echo "CMAKE_PREFIX_PATH=$(brew --prefix boost)" >> $GITHUB_ENV
 
       # ---------------- Windows ----------------
       - name: Install Boost (Windows)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         uses: jwlawson/actions-setup-cmake@v1
 
       - name: Configure
-        run: cmake -S . -B build
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
 
       - name: Build
         run: cmake --build build --config Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,34 +13,47 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup CMake
         uses: jwlawson/actions-setup-cmake@v1
 
+      # ---------------- Linux ----------------
       - name: Install Boost (Linux)
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libboost-system-dev libboost-thread-dev
+          sudo apt-get install -y build-essential cmake libboost-system-dev libboost-thread-dev
 
+      # ---------------- macOS ----------------
       - name: Install Boost (macOS)
         if: runner.os == 'macOS'
         run: |
-          brew install boost
+          brew update
+          brew install boost cmake
 
+      # ---------------- Windows ----------------
       - name: Install Boost (Windows)
         if: runner.os == 'Windows'
-        uses: egor-tensin/setup-boost@v1
-        with:
-          boost_version: 1.83.0
+        run: |
+          choco install boost-msvc-14.3 -y
+          echo "BOOST_ROOT=C:/local/boost_1_83_0" | Out-File -FilePath $env:GITHUB_ENV -Append
 
-      - name: Configure
+      # Configure
+      - name: Configure CMake
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
 
+      # Build
       - name: Build
         run: cmake --build build --config Release
 
+      # Run app (Linux & macOS only)
       - name: Run App
-        run: ./build/bin/medialode-app
         if: runner.os != 'Windows'
+        run: ./build/app/medialode-app
+
+      # Run app (Windows only)
+      - name: Run App (Windows)
+        if: runner.os == 'Windows'
+        run: ./build/app/Release/medialode-app.exe
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew update
-          brew install boost cmake sqlite
+          brew install boost sqlite
 
       # ---------------- Windows ----------------
       - name: Install Boost (Windows)

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ Makefile
 *.sqlite3
 *.db-shm
 *.db-wal
+medialode.db
+medialode.db-*

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@ CMakeFiles/
 cmake_install.cmake
 Makefile
 
+# Ignore local DBs
+*.db
+*.sqlite
+*.sqlite3
+*.db-shm
+*.db-wal

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,12 @@
 cmake_minimum_required(VERSION 3.16)
 project(medialode LANGUAGES CXX)
 
-# Set C++ standard
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Dependencies
 include(FetchContent)
 
-# --- nlohmann_json ---
+# nlohmann_json
 FetchContent_Declare(
   nlohmann_json
   GIT_REPOSITORY https://github.com/nlohmann/json.git
@@ -16,51 +14,9 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(nlohmann_json)
 
-# --- Boost (header-only for Asio/Beast) ---
+# Boost
 find_package(Boost REQUIRED COMPONENTS system)
 
-# --- OSSIA ---
-FetchContent_Declare(
-  ossia
-  GIT_REPOSITORY https://github.com/ossia/libossia.git
-  GIT_TAG master
-)
-
-include(FetchContent)
-
-# WebSocketPP
-FetchContent_Declare(
-  websocketpp
-  GIT_REPOSITORY https://github.com/zaphoyd/websocketpp.git
-  GIT_TAG        master
-)
-
-FetchContent_MakeAvailable(websocketpp)
-
-# nano-signal-slot
-FetchContent_Declare(
-  nano_signal_slot
-  GIT_REPOSITORY https://github.com/NoAvailableAlias/nano-signal-slot.git
-  GIT_TAG        master
-)
-
-FetchContent_MakeAvailable(nano_signal_slot)
-
-# Disable unused OSSIA features to speed up build
-set(OSSIA_BUILD_TESTS OFF CACHE BOOL "" FORCE)
-set(OSSIA_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
-set(OSSIA_BUILD_EDITOR OFF CACHE BOOL "" FORCE)
-set(OSSIA_BUILD_PYTHON OFF CACHE BOOL "" FORCE)
-set(OSSIA_BUILD_JAVA OFF CACHE BOOL "" FORCE)
-set(OSSIA_BUILD_MAX OFF CACHE BOOL "" FORCE)
-set(OSSIA_BUILD_PD OFF CACHE BOOL "" FORCE)
-set(OSSIA_ENABLE_INSTALL OFF CACHE BOOL "" FORCE)
-set(OSSIA_SUPERBUILD OFF CACHE BOOL "" FORCE)
-
-FetchContent_MakeAvailable(ossia)
-
-target_compile_definitions(ping-client PRIVATE ASIO_STANDALONE=0)
-
-# Add lib and app directories
+# Add subdirectories last
 add_subdirectory(lib)
 add_subdirectory(app)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,3 @@ include_directories(${CMAKE_SOURCE_DIR}/include)
 # Add subdirectories
 add_subdirectory(lib)
 add_subdirectory(app)
-
-# Optional: Add examples and tests
-# add_subdirectory(examples/hello-world)
-# add_subdirectory(tests)
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_policy(VERSION 3.5)
 cmake_minimum_required(VERSION 3.15)
 project(medialode LANGUAGES CXX)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
-cmake_policy(VERSION 3.5)
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.10)
 project(medialode LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,66 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 project(medialode LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+# Set C++ standard
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Set output directories for all targets
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+# Dependencies
+include(FetchContent)
 
-# Include folders for headers
-include_directories(${CMAKE_SOURCE_DIR}/include)
+# --- nlohmann_json ---
+FetchContent_Declare(
+  nlohmann_json
+  GIT_REPOSITORY https://github.com/nlohmann/json.git
+  GIT_TAG v3.11.3
+)
+FetchContent_MakeAvailable(nlohmann_json)
 
-# Add subdirectories
+# --- Boost (header-only for Asio/Beast) ---
+find_package(Boost REQUIRED COMPONENTS system)
+
+# --- OSSIA ---
+FetchContent_Declare(
+  ossia
+  GIT_REPOSITORY https://github.com/ossia/libossia.git
+  GIT_TAG master
+)
+
+include(FetchContent)
+
+# WebSocketPP
+FetchContent_Declare(
+  websocketpp
+  GIT_REPOSITORY https://github.com/zaphoyd/websocketpp.git
+  GIT_TAG        master
+)
+
+FetchContent_MakeAvailable(websocketpp)
+
+# nano-signal-slot
+FetchContent_Declare(
+  nano_signal_slot
+  GIT_REPOSITORY https://github.com/NoAvailableAlias/nano-signal-slot.git
+  GIT_TAG        master
+)
+
+FetchContent_MakeAvailable(nano_signal_slot)
+
+# Disable unused OSSIA features to speed up build
+set(OSSIA_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+set(OSSIA_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+set(OSSIA_BUILD_EDITOR OFF CACHE BOOL "" FORCE)
+set(OSSIA_BUILD_PYTHON OFF CACHE BOOL "" FORCE)
+set(OSSIA_BUILD_JAVA OFF CACHE BOOL "" FORCE)
+set(OSSIA_BUILD_MAX OFF CACHE BOOL "" FORCE)
+set(OSSIA_BUILD_PD OFF CACHE BOOL "" FORCE)
+set(OSSIA_ENABLE_INSTALL OFF CACHE BOOL "" FORCE)
+set(OSSIA_SUPERBUILD OFF CACHE BOOL "" FORCE)
+
+FetchContent_MakeAvailable(ossia)
+
+target_compile_definitions(ping-client PRIVATE ASIO_STANDALONE=0)
+
+# Add lib and app directories
 add_subdirectory(lib)
 add_subdirectory(app)

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,30 +1,50 @@
-# Make Boost and nlohmann_json available
+# Dependencies
 find_package(Boost REQUIRED COMPONENTS system thread)
+find_package(SQLite3 REQUIRED)
 
-# Ensure this includes the header path for ipc/protocol.hpp
-include_directories(${CMAKE_SOURCE_DIR}/lib)
-
-# Main app
-add_executable(medialode-app main.cpp)
-target_link_libraries(medialode-app PRIVATE medialode-lib)
-
-# Ping server
-add_executable(ping-server ping-server.cpp)
-target_link_libraries(ping-server
-  PRIVATE medialode-lib
-          Boost::system Boost::thread
-          nlohmann_json::nlohmann_json
+# CLI client (scan-folders-cli)
+add_executable(scan-folders-cli scan-folders-cli.cpp)
+target_include_directories(scan-folders-cli PRIVATE ${CMAKE_SOURCE_DIR}/lib)
+target_link_libraries(scan-folders-cli
+  PRIVATE
+    medialode-lib
+    Boost::system
+    Boost::thread
+    nlohmann_json::nlohmann_json
 )
 
-# Ping client
-add_executable(ping-client ping-client.cpp)
-target_link_libraries(ping-client
-  PRIVATE medialode-lib
-          nlohmann_json::nlohmann_json
+# libmgr-server (WebSocket server)
+add_executable(libmgr-server libmgr-server.cpp)
+target_include_directories(libmgr-server PRIVATE ${CMAKE_SOURCE_DIR}/lib)
+target_link_libraries(libmgr-server
+  PRIVATE
+    medialode-lib
+    Boost::system
+    Boost::thread
+    SQLite::SQLite3
+    nlohmann_json::nlohmann_json
 )
 
-target_compile_definitions(ping-client PRIVATE
-                           ASIO_STANDALONE=0
-                           _WEBSOCKETPP_CPP11_INTERNAL_
-
+#Generic Scanner Worker
+add_executable(libmgr-scan-worker libmgr-scan-worker.cpp)
+target_include_directories(libmgr-scan-worker PRIVATE ${CMAKE_SOURCE_DIR}/lib)
+target_link_libraries(libmgr-scan-worker
+  PRIVATE
+    medialode-lib
+    Boost::system
+    Boost::thread
+    nlohmann_json::nlohmann_json
 )
+
+# scan-file-cli
+add_executable(scan-file-cli
+  scan-file-cli.cpp
+)
+target_include_directories(scan-file-cli PRIVATE ${CMAKE_SOURCE_DIR}/lib)
+target_link_libraries(scan-file-cli
+  PRIVATE
+    nlohmann_json::nlohmann_json
+    Boost::system
+    Boost::thread
+)
+

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -23,15 +23,8 @@ target_link_libraries(ping-client
           nlohmann_json::nlohmann_json
 )
 
-target_compile_definitions(ping-client PRIVATE ASIO_STANDALONE=0)
+target_compile_definitions(ping-client PRIVATE
+                           ASIO_STANDALONE=0
+                           _WEBSOCKETPP_CPP11_INTERNAL_
 
-# Add OSSIA header-only include path
-target_include_directories(ping-client
-  PRIVATE
-    ${ossia_SOURCE_DIR}/src
-    ${websocketpp_SOURCE_DIR}
-    ${nano_signal_slot_SOURCE_DIR}
 )
-
-
-

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,8 +1,37 @@
-add_executable(medialode-app
-    main.cpp
+# Make Boost and nlohmann_json available
+find_package(Boost REQUIRED COMPONENTS system thread)
+
+# Ensure this includes the header path for ipc/protocol.hpp
+include_directories(${CMAKE_SOURCE_DIR}/lib)
+
+# Main app
+add_executable(medialode-app main.cpp)
+target_link_libraries(medialode-app PRIVATE medialode-lib)
+
+# Ping server
+add_executable(ping-server ping-server.cpp)
+target_link_libraries(ping-server
+  PRIVATE medialode-lib
+          Boost::system Boost::thread
+          nlohmann_json::nlohmann_json
 )
 
-target_link_libraries(medialode-app
-    PRIVATE medialode-lib
+# Ping client
+add_executable(ping-client ping-client.cpp)
+target_link_libraries(ping-client
+  PRIVATE medialode-lib
+          nlohmann_json::nlohmann_json
 )
+
+target_compile_definitions(ping-client PRIVATE ASIO_STANDALONE=0)
+
+# Add OSSIA header-only include path
+target_include_directories(ping-client
+  PRIVATE
+    ${ossia_SOURCE_DIR}/src
+    ${websocketpp_SOURCE_DIR}
+    ${nano_signal_slot_SOURCE_DIR}
+)
+
+
 

--- a/app/libmgr-scan-worker.cpp
+++ b/app/libmgr-scan-worker.cpp
@@ -1,0 +1,107 @@
+#include <boost/asio.hpp>
+#include <boost/beast/core.hpp>
+#include <boost/beast/websocket.hpp>
+#include <boost/beast/core/buffers_to_string.hpp>
+#include <iostream>
+#include <filesystem>
+#include <chrono>
+#include <string>
+#include <thread>
+#include <random>
+#include <nlohmann/json.hpp>
+#include "ipc/protocol.hpp"
+
+namespace asio = boost::asio;
+namespace beast = boost::beast;
+namespace websocket = beast::websocket;
+using tcp = asio::ip::tcp;
+namespace fs = std::filesystem;
+
+static std::string env_str(const char* k, std::string def=""){
+  if(const char* v = std::getenv(k)) return v; return def;
+}
+static const std::string WORKER_TOKEN = env_str("LIBMGR_WORKER_TOKEN", "changeme");
+
+static std::int64_t to_epoch_seconds(fs::file_time_type t){
+  using namespace std::chrono;
+  auto sctp = time_point_cast<system_clock::duration>(t - fs::file_time_type::clock::now()
+        + system_clock::now());
+  return static_cast<std::int64_t>(system_clock::to_time_t(sctp));
+}
+
+int main(int argc, char* argv[]){
+  std::string host = "127.0.0.1";
+  std::string port = "8081";
+  for(int i=1;i<argc;++i){
+    std::string a = argv[i];
+    if(a=="--host" && i+1<argc) host=argv[++i];
+    else if(a=="--port" && i+1<argc) port=argv[++i];
+  }
+
+  std::mt19937 rng{std::random_device{}()};
+
+  for(;;){ // reconnect loop
+    try{
+      asio::io_context ioc;
+
+      tcp::resolver resolver{ioc};
+      auto results = resolver.resolve(host, port);
+      websocket::stream<tcp::socket> ws{ioc};
+      ws.set_option(websocket::stream_base::timeout::suggested(beast::role_type::client));
+      asio::connect(ws.next_layer(), results);
+      ws.handshake(host, "/");
+
+      // hello + token
+      medialode::ipc::WorkerHello hello;
+      hello.token = WORKER_TOKEN;
+      ws.write(asio::buffer(nlohmann::json(hello).dump()));
+      std::cout << R"({"level":"info","msg":"worker connected"})" << "\n";
+
+      beast::flat_buffer buffer;
+      for(;;){
+        buffer.consume(buffer.size());
+        ws.read(buffer);
+        auto text = beast::buffers_to_string(buffer.data());
+        auto j = nlohmann::json::parse(text);
+        auto type = j.at("type").get<std::string>();
+
+        if(type == "PingRequest"){
+          medialode::ipc::PingResponse pr; pr.message = "pong";
+          ws.write(asio::buffer(nlohmann::json(pr).dump()));
+        } else if(type == "ScanFileRequest"){
+          auto req = j.get<medialode::ipc::ScanFileRequest>();
+          medialode::ipc::IPCMessage reply;
+          try{
+            fs::path p{req.path};
+            if(!fs::exists(p) || !fs::is_regular_file(p)){
+              medialode::ipc::FileError fe{.type="FileError", .request_id=req.request_id, .path=req.path, .error="not a regular file or missing"};
+              reply = fe;
+            } else {
+              medialode::ipc::FileScanned ok;
+              ok.request_id = req.request_id;
+              ok.path = req.path;
+              ok.size = fs::file_size(p);
+              ok.mtime = to_epoch_seconds(fs::last_write_time(p));
+              reply = ok;
+            }
+          }catch(const std::exception& e){
+            medialode::ipc::FileError fe;
+            fe.request_id = req.request_id; fe.path = req.path; fe.error = e.what();
+            reply = fe;
+          }
+          ws.write(asio::buffer(medialode::ipc::to_text(reply)));
+        }
+      }
+    }catch(const std::exception& e){
+      std::cerr << R"({"level":"error","msg":"worker disconnected","err":")" << e.what() << "\"}\n";
+      // exponential backoff 0.5s..30s with jitter
+      static int attempt = 0;
+      int backoff_ms = std::min(30000, (1<<std::min(attempt, 10)) * 500);
+      std::uniform_int_distribution<int> jitter(0, backoff_ms/4);
+      std::this_thread::sleep_for(std::chrono::milliseconds(backoff_ms + jitter(rng)));
+      ++attempt;
+      continue;
+    }
+  }
+}
+

--- a/app/libmgr-server.cpp
+++ b/app/libmgr-server.cpp
@@ -1,4 +1,3 @@
-// app/libmgr-server.cpp
 #include <boost/asio.hpp>
 #include <boost/beast.hpp>
 #include <iostream>
@@ -28,7 +27,7 @@ namespace fs = std::filesystem;
 
 static constexpr const char* DEFAULT_DB = "medialode.db";
 
-// ---------- Config ----------
+// Config
 static std::string env_str(const char* k, std::string def=""){
   if(const char* v = std::getenv(k)) return v;
   return def;
@@ -38,7 +37,7 @@ static const std::size_t MAX_WRITE_QUEUE = 1024;
 static const std::size_t MAX_MESSAGE_SIZE = 2 * 1024 * 1024;
 static const std::vector<fs::path> ALLOWED_ROOTS = { fs::path("/") };
 
-// ---------- Logger ----------
+// Logger
 static void logj(const std::string& level, const std::string& msg,
                  std::optional<std::string> req_id = std::nullopt){
   nlohmann::json j{{"level",level},{"msg",msg}};
@@ -46,7 +45,7 @@ static void logj(const std::string& level, const std::string& msg,
   std::cout << j.dump() << std::endl;
 }
 
-// ---------- SQLite ----------
+// SQLite
 struct DbHandle {
   sqlite3* db = nullptr;
   ~DbHandle(){ if(db) sqlite3_close(db); }
@@ -120,7 +119,7 @@ static void upsert_file(sqlite3* db, const std::string& path,
   sqlite3_finalize(stmt);
 }
 
-// ---------- Dedicated DB executor ----------
+// Dedicated DB executor
 class DBExecutor {
 public:
   explicit DBExecutor(std::unique_ptr<DbHandle> dbh)
@@ -160,7 +159,7 @@ private:
   std::thread t_;
 };
 
-// ---------- Shared state ----------
+// Shared state
 struct WebSocketSession;
 struct ServerState {
   std::mutex m;
@@ -190,7 +189,7 @@ struct ServerState {
   }
 };
 
-// ---------- Session ----------
+// Session
 class WebSocketSession : public std::enable_shared_from_this<WebSocketSession> {
   websocket::stream<tcp::socket> ws_;
   beast::flat_buffer buf_;
@@ -351,7 +350,7 @@ public:
   }
 };
 
-// ---------- run_server ----------
+// run_server
 void run_server(asio::io_context& ioc,std::uint16_t port,const std::string& dbfile){
   static ServerState state;
   static DBExecutor dbx(open_db(dbfile));

--- a/app/libmgr-server.cpp
+++ b/app/libmgr-server.cpp
@@ -1,0 +1,398 @@
+// app/libmgr-server.cpp
+#include <boost/asio.hpp>
+#include <boost/beast.hpp>
+#include <iostream>
+#include <memory>
+#include <thread>
+#include <atomic>
+#include <filesystem>
+#include <chrono>
+#include <sqlite3.h>
+#include <deque>
+#include <unordered_map>
+#include <mutex>
+#include <csignal>
+#include <optional>
+#include <future>
+#include <vector>
+#include <utility>
+#include <type_traits>
+
+#include "ipc/protocol.hpp"
+
+namespace asio = boost::asio;
+namespace beast = boost::beast;
+namespace websocket = beast::websocket;
+using tcp = asio::ip::tcp;
+namespace fs = std::filesystem;
+
+static constexpr const char* DEFAULT_DB = "medialode.db";
+
+// ---------- Config ----------
+static std::string env_str(const char* k, std::string def=""){
+  if(const char* v = std::getenv(k)) return v;
+  return def;
+}
+static const std::string WORKER_TOKEN = env_str("LIBMGR_WORKER_TOKEN", "changeme");
+static const std::size_t MAX_WRITE_QUEUE = 1024;
+static const std::size_t MAX_MESSAGE_SIZE = 2 * 1024 * 1024;
+static const std::vector<fs::path> ALLOWED_ROOTS = { fs::path("/") };
+
+// ---------- Logger ----------
+static void logj(const std::string& level, const std::string& msg,
+                 std::optional<std::string> req_id = std::nullopt){
+  nlohmann::json j{{"level",level},{"msg",msg}};
+  if(req_id) j["request_id"] = *req_id;
+  std::cout << j.dump() << std::endl;
+}
+
+// ---------- SQLite ----------
+struct DbHandle {
+  sqlite3* db = nullptr;
+  ~DbHandle(){ if(db) sqlite3_close(db); }
+};
+
+static int sqlite_busy_cb(void*, int){
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  return 1;
+}
+
+static void exec_retry(sqlite3* db, const char* sql){
+  for(;;){
+    char* errmsg = nullptr;
+    int rc = sqlite3_exec(db, sql, nullptr, nullptr, &errmsg);
+    if(rc == SQLITE_OK) return;
+    if(rc == SQLITE_BUSY){
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      continue;
+    }
+    std::string e = errmsg ? errmsg : sqlite3_errmsg(db);
+    if(errmsg) sqlite3_free(errmsg);
+    throw std::runtime_error("sqlite error: " + e + " for SQL: " + sql);
+  }
+}
+
+static std::unique_ptr<DbHandle> open_db(const std::string& path){
+  auto h = std::make_unique<DbHandle>();
+  if(sqlite3_open(path.c_str(), &h->db) != SQLITE_OK){
+    throw std::runtime_error("Failed to open DB: " +
+      std::string(sqlite3_errmsg(h->db)));
+  }
+  sqlite3_busy_handler(h->db, &sqlite_busy_cb, nullptr);
+  sqlite3_busy_timeout(h->db, 5000);
+
+  exec_retry(h->db, "PRAGMA journal_mode = WAL;");
+  exec_retry(h->db, "PRAGMA synchronous = NORMAL;");
+  exec_retry(h->db, "PRAGMA foreign_keys = ON;");
+
+  exec_retry(h->db, "CREATE TABLE IF NOT EXISTS folders (path TEXT PRIMARY KEY, last_scan INTEGER);");
+  exec_retry(h->db, "CREATE TABLE IF NOT EXISTS files (path TEXT PRIMARY KEY, folder_path TEXT, mtime INTEGER);");
+  exec_retry(h->db, "CREATE INDEX IF NOT EXISTS idx_files_folder ON files(folder_path);");
+
+  return h;
+}
+
+static void upsert_folder(sqlite3* db, const std::string& path, std::int64_t last_scan){
+  sqlite3_stmt* stmt=nullptr;
+  const char* sql="INSERT INTO folders(path,last_scan) VALUES(?,?) "
+                  "ON CONFLICT(path) DO UPDATE SET last_scan=excluded.last_scan;";
+  if(sqlite3_prepare_v2(db, sql, -1, &stmt, nullptr) != SQLITE_OK)
+    throw std::runtime_error(sqlite3_errmsg(db));
+  sqlite3_bind_text(stmt,1,path.c_str(),-1,SQLITE_TRANSIENT);
+  sqlite3_bind_int64(stmt,2,last_scan);
+  if(sqlite3_step(stmt) != SQLITE_DONE)
+    throw std::runtime_error(sqlite3_errmsg(db));
+  sqlite3_finalize(stmt);
+}
+
+static void upsert_file(sqlite3* db, const std::string& path,
+                        const std::string& folder, std::int64_t mtime){
+  sqlite3_stmt* stmt=nullptr;
+  const char* sql="INSERT INTO files(path,folder_path,mtime) VALUES(?,?,?) "
+                  "ON CONFLICT(path) DO UPDATE SET folder_path=excluded.folder_path, mtime=excluded.mtime;";
+  if(sqlite3_prepare_v2(db, sql, -1, &stmt, nullptr) != SQLITE_OK)
+    throw std::runtime_error(sqlite3_errmsg(db));
+  sqlite3_bind_text(stmt,1,path.c_str(),-1,SQLITE_TRANSIENT);
+  sqlite3_bind_text(stmt,2,folder.c_str(),-1,SQLITE_TRANSIENT);
+  sqlite3_bind_int64(stmt,3,mtime);
+  if(sqlite3_step(stmt) != SQLITE_DONE)
+    throw std::runtime_error(sqlite3_errmsg(db));
+  sqlite3_finalize(stmt);
+}
+
+// ---------- Dedicated DB executor ----------
+class DBExecutor {
+public:
+  explicit DBExecutor(std::unique_ptr<DbHandle> dbh)
+    : dbh_(std::move(dbh)),
+      guard_(asio::make_work_guard(ioc_)),
+      t_([this]{ ioc_.run(); }) {}
+
+  ~DBExecutor(){
+    guard_.reset();
+    ioc_.stop();
+    if(t_.joinable()) t_.join();
+  }
+
+  template<class F>
+  auto exec(F&& f) -> std::future<std::invoke_result_t<F, sqlite3*>> {
+    using R = std::invoke_result_t<F, sqlite3*>;
+    auto prom = std::make_shared<std::promise<R>>();
+    asio::post(ioc_, [this, prom, fn = std::forward<F>(f)]() mutable {
+      try {
+        if constexpr(std::is_void_v<R>) {
+          fn(dbh_->db);
+          prom->set_value();
+        } else {
+          prom->set_value(fn(dbh_->db));
+        }
+      } catch(...) {
+        prom->set_exception(std::current_exception());
+      }
+    });
+    return prom->get_future();
+  }
+
+private:
+  std::unique_ptr<DbHandle> dbh_;
+  asio::io_context ioc_;
+  asio::executor_work_guard<asio::io_context::executor_type> guard_;
+  std::thread t_;
+};
+
+// ---------- Shared state ----------
+struct WebSocketSession;
+struct ServerState {
+  std::mutex m;
+  std::vector<std::weak_ptr<WebSocketSession>> workers;
+  std::unordered_map<std::string, std::weak_ptr<WebSocketSession>> pending;
+  void add_worker(const std::shared_ptr<WebSocketSession>& s){
+    std::lock_guard lk(m); workers.push_back(s);
+  }
+  std::shared_ptr<WebSocketSession> get_any_worker(){
+    std::lock_guard lk(m);
+    for(auto it=workers.begin(); it!=workers.end();){
+      if(auto sp=it->lock()) return sp;
+      it = workers.erase(it);
+    }
+    return nullptr;
+  }
+  void map_request(const std::string& id, std::shared_ptr<WebSocketSession> c){
+    std::lock_guard lk(m); pending[id] = c;
+  }
+  std::shared_ptr<WebSocketSession> take_client(const std::string& id){
+    std::lock_guard lk(m);
+    auto it=pending.find(id);
+    if(it==pending.end()) return nullptr;
+    auto sp=it->second.lock();
+    pending.erase(it);
+    return sp;
+  }
+};
+
+// ---------- Session ----------
+class WebSocketSession : public std::enable_shared_from_this<WebSocketSession> {
+  websocket::stream<tcp::socket> ws_;
+  beast::flat_buffer buf_;
+  DBExecutor& dbx_;
+  ServerState& state_;
+  enum class Role{Client,Worker} role_=Role::Client;
+  std::deque<std::string> wq_;
+  asio::steady_timer ping_;
+  bool got_pong_=true;
+
+public:
+  WebSocketSession(tcp::socket sock, DBExecutor& dbx, ServerState& st)
+    : ws_(std::move(sock)), dbx_(dbx), state_(st),
+      ping_(ws_.get_executor()) {}
+
+  void start(){
+    ws_.set_option(websocket::stream_base::timeout::suggested(beast::role_type::server));
+    ws_.read_message_max(MAX_MESSAGE_SIZE);
+    ws_.control_callback([this](websocket::frame_type k, boost::beast::string_view){
+      if(k==websocket::frame_type::pong) got_pong_=true;
+    });
+    auto self=shared_from_this();
+    ws_.async_accept([self](beast::error_code ec){
+      if(!ec){ logj("info","session accepted"); self->schedule_ping(); self->do_read(); }
+      else logj("error","accept: "+ec.message());
+    });
+  }
+
+  void schedule_ping(){
+    auto self=shared_from_this();
+    ping_.expires_after(std::chrono::seconds(15));
+    ping_.async_wait([self](beast::error_code ec){
+      if(ec) return;
+      if(!self->got_pong_){
+        logj("warn","no pong, closing");
+        beast::error_code ignore;
+        self->ws_.close(websocket::close_code::going_away, ignore);
+        return;
+      }
+      self->got_pong_=false;
+      self->ws_.async_ping({}, [self](beast::error_code){ self->schedule_ping(); });
+    });
+  }
+
+  void do_read(){
+    auto self=shared_from_this();
+    ws_.async_read(buf_, [self](beast::error_code ec,std::size_t){
+      if(ec){ logj("info", ec==websocket::error::closed?"session closed":"read:"+ec.message()); return; }
+      std::string msg=beast::buffers_to_string(self->buf_.data());
+      self->buf_.consume(self->buf_.size());
+      self->handle(msg);
+      self->do_read();
+    });
+  }
+
+  void handle(const std::string& msg){
+    try{
+      auto j=nlohmann::json::parse(msg);
+      auto type=j.at("type").get<std::string>();
+
+      if(type=="PingRequest"){
+        medialode::ipc::PingResponse r; r.message="pong";
+        enqueue(nlohmann::json(r).dump());
+      }
+      else if(type=="WorkerHello"){
+        auto hello = j.get<medialode::ipc::WorkerHello>();
+        if(hello.token != WORKER_TOKEN){
+          logj("warn","worker auth failed");
+          ws_.close(websocket::close_code::policy_error);
+          return;
+        }
+        role_=Role::Worker;
+        state_.add_worker(shared_from_this());
+        logj("info","worker registered: "+hello.name);
+      }
+      else if(type=="ClientHello"){
+        logj("info","client connected");
+      }
+      else if(type=="ScanFoldersRequest"){
+        auto req=j.get<medialode::ipc::ScanFoldersRequest>();
+        auto self=shared_from_this();
+        std::thread([self,req](){
+          try{
+            std::vector<std::string> folders;
+            std::vector<std::tuple<std::string,std::string,std::int64_t>> files;
+            std::size_t fcount=0, flcount=0;
+            auto now=(int64_t)std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+            for(auto& raw:req.paths){
+              fs::path root(raw);
+              if(!fs::exists(root)) continue;
+              folders.push_back(root.string()); fcount++;
+              for(auto it=fs::recursive_directory_iterator(root,fs::directory_options::skip_permission_denied);
+                  it!=fs::recursive_directory_iterator();++it){
+                if(it->is_directory()){ folders.push_back(it->path().string()); fcount++; }
+                else if(it->is_regular_file()){
+                  auto mtime=std::chrono::duration_cast<std::chrono::seconds>(it->last_write_time().time_since_epoch()).count();
+                  files.emplace_back(it->path().string(),it->path().parent_path().string(),mtime);
+                  flcount++;
+                }
+              }
+            }
+            auto fut=self->dbx_.exec([folders=std::move(folders),files=std::move(files),now](sqlite3* db){
+              exec_retry(db,"BEGIN;");
+              try{
+                for(auto& f:folders) upsert_folder(db,f,now);
+                for(auto& t:files) upsert_file(db,std::get<0>(t),std::get<1>(t),std::get<2>(t));
+                exec_retry(db,"COMMIT;");
+              }catch(...){ exec_retry(db,"ROLLBACK;"); throw; }
+            });
+            fut.get();
+            medialode::ipc::ScanFoldersResponse resp;
+            resp.scanned_folders=fcount; resp.scanned_files=flcount;
+            self->enqueue(nlohmann::json(resp).dump());
+          }catch(const std::exception&e){ logj("error","scan-folders:"+std::string(e.what())); }
+        }).detach();
+      }
+      else if(type=="ScanFileRequest" && role_==Role::Client){
+        auto req=j.get<medialode::ipc::ScanFileRequest>();
+        if(req.request_id.empty()){
+          medialode::ipc::FileError fe; fe.request_id=""; fe.path=req.path; fe.error="missing request_id";
+          enqueue(nlohmann::json(fe).dump());
+        }else{
+          auto worker=state_.get_any_worker();
+          if(!worker){
+            medialode::ipc::FileError fe; fe.request_id=req.request_id; fe.path=req.path; fe.error="no worker available";
+            enqueue(nlohmann::json(fe).dump());
+          }else{
+            state_.map_request(req.request_id, shared_from_this());
+            worker->enqueue(j.dump());
+          }
+        }
+      }
+      else if((type=="FileScanned"||type=="FileError") && role_==Role::Worker){
+        std::string reqid=j.at("request_id").get<std::string>();
+        if(auto client=state_.take_client(reqid)){
+          client->enqueue(j.dump());
+        }
+      }
+      else{
+        logj("warn","unknown msg type: "+type);
+      }
+    }catch(const std::exception&e){ logj("error","json:"+std::string(e.what())); }
+  }
+
+  void enqueue(std::string payload){
+    bool idle=wq_.empty();
+    wq_.push_back(std::move(payload));
+    if(idle) do_write();
+  }
+
+  void do_write(){
+    auto self=shared_from_this();
+    ws_.async_write(asio::buffer(wq_.front()), [self](beast::error_code ec,std::size_t){
+      if(ec){ logj("error","write:"+ec.message()); return; }
+      self->wq_.pop_front();
+      if(!self->wq_.empty()) self->do_write();
+    });
+  }
+};
+
+// ---------- run_server ----------
+void run_server(asio::io_context& ioc,std::uint16_t port,const std::string& dbfile){
+  static ServerState state;
+  static DBExecutor dbx(open_db(dbfile));
+  auto acceptor=std::make_shared<tcp::acceptor>(ioc);
+  beast::error_code ec;
+  tcp::endpoint ep{tcp::v4(),port};
+  acceptor->open(ep.protocol(),ec); acceptor->set_option(asio::socket_base::reuse_address(true));
+  acceptor->bind(ep,ec); acceptor->listen(asio::socket_base::max_listen_connections,ec);
+  logj("info","libmgr-server starting on ws://localhost:"+std::to_string(port));
+  logj("info","db="+dbfile);
+
+  auto do_accept=std::make_shared<std::function<void()>>();
+  *do_accept=[acceptor,&dbx,&state,do_accept](){
+    acceptor->async_accept([acceptor,&dbx,&state,do_accept](beast::error_code ec,tcp::socket sock){
+      if(!ec) std::make_shared<WebSocketSession>(std::move(sock),dbx,state)->start();
+      if(acceptor->is_open()) (*do_accept)();
+    });
+  };
+  (*do_accept)();
+
+  static std::shared_ptr<asio::signal_set> signals;
+  signals=std::make_shared<asio::signal_set>(ioc,SIGINT,SIGTERM);
+  signals->async_wait([acceptor](const beast::error_code&,int){
+    logj("info","shutdown requested");
+    beast::error_code ignore; acceptor->close(ignore);
+  });
+}
+
+int main(int argc,char*argv[]){
+  try{
+    std::string dbfile=DEFAULT_DB;
+    std::uint16_t port=8081;
+    if(argc>1) dbfile=argv[1];
+    if(argc>2) port=(std::uint16_t)std::atoi(argv[2]);
+    asio::io_context ioc;
+    run_server(ioc,port,dbfile);
+    ioc.run();
+    return 0;
+  }catch(const std::exception&e){
+    logj("fatal",e.what());
+    return 1;
+  }
+}
+

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -1,7 +1,0 @@
-#include <medialode/file_watcher.hpp>
-
-int main()
-{
-    test_llfio();
-    return 0;
-}

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -1,8 +1,7 @@
-#include <iostream>
+#include <medialode/file_watcher.hpp>
 
 int main()
 {
-    std::cout << "Welcome to Medialode!\n";
+    test_llfio();
     return 0;
 }
-

--- a/app/ping-client.cpp
+++ b/app/ping-client.cpp
@@ -1,46 +1,64 @@
-#include <boost/beast/core.hpp>
-#include <boost/beast/websocket.hpp>
-#include <boost/asio/ip/tcp.hpp>
-#include <nlohmann/json.hpp>
 #include <iostream>
-#include "ipc/protocol.hpp"
+#include <string>
+#include <nlohmann/json.hpp>
+#include "../lib/ipc/protocol.hpp"
+#include <websocketpp/config/asio_no_tls_client.hpp>
+#include <websocketpp/client.hpp>
 
-namespace beast = boost::beast;
-namespace websocket = beast::websocket;
-namespace net = boost::asio;
-using tcp = net::ip::tcp;
+using json = nlohmann::json;
+typedef websocketpp::client<websocketpp::config::asio_client> client;
 
 int main() {
-    try {
-        net::io_context ioc;
-        tcp::resolver resolver(ioc);
-        websocket::stream<tcp::socket> ws(ioc);
+    client c;
+    std::string uri = "ws://localhost:8081";
 
-        auto const results = resolver.resolve("127.0.0.1", "37587");
-        net::connect(ws.next_layer(), results.begin(), results.end());
+    c.init_asio();
 
-        ws.handshake("127.0.0.1:37587", "/");
+    c.set_message_handler([&](websocketpp::connection_hdl, client::message_ptr msg) {
+        try {
+            auto parsed = parseMessage(msg->get_payload());
 
-        // Send PingRequest
-        medialode::ipc::PingRequest ping;
-        auto env = medialode::ipc::make_envelope(ping);
-        ws.write(net::buffer(nlohmann::json(env).dump()));
-
-        // Read PongResponse
-        beast::flat_buffer buffer;
-        ws.read(buffer);
-        auto msg = beast::buffers_to_string(buffer.data());
-
-        auto envelope = nlohmann::json::parse(msg).get<medialode::ipc::MessageEnvelope>();
-        auto var = medialode::ipc::parse_variant(envelope);
-        if (auto* pong = std::get_if<medialode::ipc::PingResponse>(&var)) {
-            std::cout << "Received pong: " << pong->message << "\n";
+            std::visit([&](auto&& m) {
+                using T = std::decay_t<decltype(m)>;
+                if constexpr (std::is_same_v<T, PingResponse>) {
+                    std::cout << "[Server]: PingResponse: " << m.message << "\n";
+                } else if constexpr (std::is_same_v<T, ScanFoldersResponse>) {
+                    std::cout << "[Server]: ScanFoldersResponse: status=" << m.status
+                              << " scanned_count=" << m.scanned_count << "\n";
+                } else {
+                    std::cout << "[Server]: Unknown response type\n";
+                }
+            }, parsed);
+        } catch (const std::exception& e) {
+            std::cerr << "Error parsing response: " << e.what() << "\n";
         }
+    });
 
-        ws.close(websocket::close_code::normal);
+    websocketpp::lib::error_code ec;
+    auto con = c.get_connection(uri, ec);
+    if (ec) {
+        std::cerr << "Connection error: " << ec.message() << "\n";
+        return 1;
     }
-    catch (std::exception const& e) {
-        std::cerr << "Error: " << e.what() << "\n";
-    }
+
+    c.connect(con);
+    std::thread t([&] { c.run(); });
+
+    // Send a PingRequest
+    PingRequest ping;
+    json j_ping = ping;
+    c.send(con->get_handle(), j_ping.dump(), websocketpp::frame::opcode::text);
+
+    std::cout << "Sent PingRequest.\n";
+
+    // Send a ScanFoldersRequest
+    ScanFoldersRequest scan;
+    scan.paths = {"/home/user/Music", "/mnt/external/Movies"};
+    json j_scan = scan;
+    c.send(con->get_handle(), j_scan.dump(), websocketpp::frame::opcode::text);
+
+    std::cout << "Sent ScanFoldersRequest.\n";
+
+    t.join();
 }
 

--- a/app/ping-client.cpp
+++ b/app/ping-client.cpp
@@ -1,41 +1,46 @@
-#define BOOST_ASIO_NO_DEPRECATED
-#define _WEBSOCKETPP_CPP11_STL_
-#define _WEBSOCKETPP_CPP11_FUNCTIONAL_
-#define _WEBSOCKETPP_CPP11_TYPE_TRAITS_
-
-#define ASIO_STANDALONE 0
-
-#include <boost/asio.hpp>
-#include <ossia/network/sockets/websocket.hpp>
+#include <boost/beast/core.hpp>
+#include <boost/beast/websocket.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <nlohmann/json.hpp>
 #include <iostream>
 #include "ipc/protocol.hpp"
 
+namespace beast = boost::beast;
+namespace websocket = beast::websocket;
+namespace net = boost::asio;
+using tcp = net::ip::tcp;
+
 int main() {
-  boost::asio::io_context ctx;
-  ossia::net::websocket_simple_client socket{{.url = "ws://127.0.0.1:37587"}, ctx};
+    try {
+        net::io_context ioc;
+        tcp::resolver resolver(ioc);
+        websocket::stream<tcp::socket> ws(ioc);
 
-  socket.on_open.connect([&] {
-    medialode::ipc::PingRequest ping;
-    medialode::ipc::MessageEnvelope env = medialode::ipc::make_envelope(ping);
-    nlohmann::json j = env;
-    socket.send_message(j.dump());
-  });
+        auto const results = resolver.resolve("127.0.0.1", "37587");
+        net::connect(ws.next_layer(), results.begin(), results.end());
 
-  socket.on_message.connect([&](const std::string& msg) {
-    auto j = nlohmann::json::parse(msg);
-    auto envelope = j.get<medialode::ipc::MessageEnvelope>();
-    auto var = medialode::ipc::parse_variant(envelope);
+        ws.handshake("127.0.0.1:37587", "/");
 
-    if (auto* pong = std::get_if<medialode::ipc::PingResponse>(&var)) {
-      std::cout << "Received pong: " << pong->message << "\n";
-      socket.close();
+        // Send PingRequest
+        medialode::ipc::PingRequest ping;
+        auto env = medialode::ipc::make_envelope(ping);
+        ws.write(net::buffer(nlohmann::json(env).dump()));
+
+        // Read PongResponse
+        beast::flat_buffer buffer;
+        ws.read(buffer);
+        auto msg = beast::buffers_to_string(buffer.data());
+
+        auto envelope = nlohmann::json::parse(msg).get<medialode::ipc::MessageEnvelope>();
+        auto var = medialode::ipc::parse_variant(envelope);
+        if (auto* pong = std::get_if<medialode::ipc::PingResponse>(&var)) {
+            std::cout << "Received pong: " << pong->message << "\n";
+        }
+
+        ws.close(websocket::close_code::normal);
     }
-  });
-
-  socket.on_fail.connect([] { std::cerr << "Connection failed\n"; });
-  socket.on_close.connect([] { std::cout << "Connection closed\n"; });
-
-  socket.connect("ws://127.0.0.1:37587");
-  ctx.run();
+    catch (std::exception const& e) {
+        std::cerr << "Error: " << e.what() << "\n";
+    }
 }
 

--- a/app/ping-client.cpp
+++ b/app/ping-client.cpp
@@ -1,0 +1,41 @@
+#define BOOST_ASIO_NO_DEPRECATED
+#define _WEBSOCKETPP_CPP11_STL_
+#define _WEBSOCKETPP_CPP11_FUNCTIONAL_
+#define _WEBSOCKETPP_CPP11_TYPE_TRAITS_
+
+#define ASIO_STANDALONE 0
+
+#include <boost/asio.hpp>
+#include <ossia/network/sockets/websocket.hpp>
+#include <iostream>
+#include "ipc/protocol.hpp"
+
+int main() {
+  boost::asio::io_context ctx;
+  ossia::net::websocket_simple_client socket{{.url = "ws://127.0.0.1:37587"}, ctx};
+
+  socket.on_open.connect([&] {
+    medialode::ipc::PingRequest ping;
+    medialode::ipc::MessageEnvelope env = medialode::ipc::make_envelope(ping);
+    nlohmann::json j = env;
+    socket.send_message(j.dump());
+  });
+
+  socket.on_message.connect([&](const std::string& msg) {
+    auto j = nlohmann::json::parse(msg);
+    auto envelope = j.get<medialode::ipc::MessageEnvelope>();
+    auto var = medialode::ipc::parse_variant(envelope);
+
+    if (auto* pong = std::get_if<medialode::ipc::PingResponse>(&var)) {
+      std::cout << "Received pong: " << pong->message << "\n";
+      socket.close();
+    }
+  });
+
+  socket.on_fail.connect([] { std::cerr << "Connection failed\n"; });
+  socket.on_close.connect([] { std::cout << "Connection closed\n"; });
+
+  socket.connect("ws://127.0.0.1:37587");
+  ctx.run();
+}
+

--- a/app/ping-server.cpp
+++ b/app/ping-server.cpp
@@ -1,0 +1,74 @@
+#include <boost/asio.hpp>
+#include <boost/beast.hpp>
+#include <iostream>
+#include <memory>
+#include "ipc/protocol.hpp"
+
+namespace asio = boost::asio;
+namespace beast = boost::beast;
+namespace websocket = beast::websocket;
+using tcp = asio::ip::tcp;
+
+class WebSocketSession : public std::enable_shared_from_this<WebSocketSession> {
+  websocket::stream<tcp::socket> ws_;
+  beast::flat_buffer buffer_;
+
+public:
+  explicit WebSocketSession(tcp::socket socket)
+    : ws_(std::move(socket)) {}
+
+  void start() {
+    ws_.async_accept([self = shared_from_this()](beast::error_code ec) {
+      if (!ec) self->do_read();
+    });
+  }
+
+  void do_read() {
+    ws_.async_read(buffer_, [self = shared_from_this()](beast::error_code ec, std::size_t) {
+      if (ec) return;
+
+      try {
+        auto msg_text = beast::buffers_to_string(self->buffer_.data());
+        auto j = nlohmann::json::parse(msg_text);
+        auto envelope = j.get<medialode::ipc::MessageEnvelope>();
+        auto var = medialode::ipc::parse_variant(envelope);
+
+        // Handle PingRequest
+        if (std::holds_alternative<medialode::ipc::PingRequest>(var)) {
+          medialode::ipc::PingResponse resp;
+          auto reply = medialode::ipc::make_envelope(resp);
+          nlohmann::json jresp = reply;
+          self->ws_.async_write(
+            asio::buffer(jresp.dump()), [](beast::error_code, std::size_t) {});
+        }
+      } catch (const std::exception& e) {
+        std::cerr << "Error: " << e.what() << '\n';
+      }
+
+      self->buffer_.consume(self->buffer_.size());
+      self->do_read(); // continue reading
+    });
+  }
+};
+
+void run_server(asio::io_context& ioc, uint16_t port = 37587) {
+  tcp::acceptor acceptor{ioc, {tcp::v4(), port}};
+  std::cout << "Server running on ws://localhost:" << port << "\n";
+
+  std::function<void()> do_accept;
+  do_accept = [&]() {
+    acceptor.async_accept([&](beast::error_code ec, tcp::socket socket) {
+      if (!ec)
+        std::make_shared<WebSocketSession>(std::move(socket))->start();
+      do_accept();
+    });
+  };
+
+  do_accept();
+}
+
+int main() {
+  boost::asio::io_context ctx;
+  run_server(ctx, 37587);
+  ctx.run();
+}

--- a/app/ping-server.cpp
+++ b/app/ping-server.cpp
@@ -18,57 +18,93 @@ public:
     : ws_(std::move(socket)) {}
 
   void start() {
-    ws_.async_accept([self = shared_from_this()](beast::error_code ec) {
-      if (!ec) self->do_read();
+    std::cout << "[Session] Starting new WebSocket session\n";
+    auto self = shared_from_this();
+    ws_.async_accept([self](beast::error_code ec) {
+      if (!ec) {
+        std::cout << "[Session] Connection accepted\n";
+        self->do_read();
+      } else {
+        std::cerr << "[Session] Accept error: " << ec.message() << "\n";
+      }
     });
   }
 
   void do_read() {
-    ws_.async_read(buffer_, [self = shared_from_this()](beast::error_code ec, std::size_t) {
-      if (ec) return;
+    auto self = shared_from_this();
+    ws_.async_read(buffer_, [self](beast::error_code ec, std::size_t bytes_transferred) {
+      if (ec) {
+        if (ec == websocket::error::closed) {
+          std::cout << "[Session] Connection closed by client\n";
+        } else {
+          std::cerr << "[Session] Read error: " << ec.message() << "\n";
+        }
+        return;
+      }
 
       try {
-        auto msg_text = beast::buffers_to_string(self->buffer_.data());
+        std::string msg_text = beast::buffers_to_string(self->buffer_.data());
+        self->buffer_.consume(self->buffer_.size()); // ✅ consume immediately
+
+        std::cout << "[Session] Received message: " << msg_text << "\n";
+
+        // Parse JSON and handle IPC
         auto j = nlohmann::json::parse(msg_text);
         auto envelope = j.get<medialode::ipc::MessageEnvelope>();
         auto var = medialode::ipc::parse_variant(envelope);
 
-        // Handle PingRequest
         if (std::holds_alternative<medialode::ipc::PingRequest>(var)) {
+          std::cout << "[Session] Handling PingRequest -> Sending PingResponse\n";
           medialode::ipc::PingResponse resp;
           auto reply = medialode::ipc::make_envelope(resp);
           nlohmann::json jresp = reply;
+
           self->ws_.async_write(
-            asio::buffer(jresp.dump()), [](beast::error_code, std::size_t) {});
+            asio::buffer(jresp.dump()),
+            [self](beast::error_code ec, std::size_t) {
+              if (ec) {
+                std::cerr << "[Session] Write error: " << ec.message() << "\n";
+              } else {
+                std::cout << "[Session] Response sent successfully\n";
+              }
+            }
+          );
         }
       } catch (const std::exception& e) {
-        std::cerr << "Error: " << e.what() << '\n';
+        std::cerr << "[Session] Exception: " << e.what() << '\n';
       }
 
-      self->buffer_.consume(self->buffer_.size());
-      self->do_read(); // continue reading
+      self->do_read(); // Keep reading messages
     });
   }
 };
 
 void run_server(asio::io_context& ioc, uint16_t port = 37587) {
-  tcp::acceptor acceptor{ioc, {tcp::v4(), port}};
-  std::cout << "Server running on ws://localhost:" << port << "\n";
+  auto acceptor = std::make_shared<tcp::acceptor>(ioc, tcp::endpoint(tcp::v4(), port));
+  std::cout << "[Server] Running on ws://localhost:" << port << "\n";
 
-  std::function<void()> do_accept;
-  do_accept = [&]() {
-    acceptor.async_accept([&](beast::error_code ec, tcp::socket socket) {
-      if (!ec)
+  auto do_accept = std::make_shared<std::function<void()>>();
+  *do_accept = [acceptor, do_accept]() {
+    acceptor->async_accept([acceptor, do_accept](beast::error_code ec, tcp::socket socket) {
+      if (!ec) {
+        std::cout << "[Server] New connection accepted\n";
         std::make_shared<WebSocketSession>(std::move(socket))->start();
-      do_accept();
+      } else {
+        std::cerr << "[Server] Accept error: " << ec.message() << "\n";
+      }
+      (*do_accept)(); // Continue accepting new clients
     });
   };
 
-  do_accept();
+  (*do_accept)();
 }
 
 int main() {
-  boost::asio::io_context ctx;
-  run_server(ctx, 37587);
-  ctx.run();
+  try {
+    boost::asio::io_context ctx;
+    run_server(ctx, 37587);
+    ctx.run();
+  } catch (const std::exception& e) {
+    std::cerr << "[Fatal] Exception in main: " << e.what() << "\n";
+  }
 }

--- a/app/scan-file-cli.cpp
+++ b/app/scan-file-cli.cpp
@@ -1,0 +1,72 @@
+#include <boost/asio.hpp>
+#include <boost/beast/core.hpp>
+#include <boost/beast/websocket.hpp>
+#include <boost/beast/core/buffers_to_string.hpp>
+#include <iostream>
+#include <string>
+#include <nlohmann/json.hpp>
+#include "ipc/protocol.hpp"
+
+namespace asio = boost::asio;
+namespace beast = boost::beast;
+namespace websocket = beast::websocket;
+using tcp = asio::ip::tcp;
+
+int main(int argc, char* argv[]) {
+  std::string host = "127.0.0.1";
+  std::string port = "8081";
+  std::string path;
+
+  // Arg parsing
+  for (int i = 1; i < argc; ++i) {
+    std::string a = argv[i];
+    if (a == "--host" && i + 1 < argc) host = argv[++i];
+    else if (a == "--port" && i + 1 < argc) port = argv[++i];
+    else if (a == "--help" || a == "-h") {
+      std::cout << "Usage: scan-file-cli [--host HOST] [--port PORT] <file>\n";
+      return 0;
+    } else {
+      path = a;
+    }
+  }
+
+  if (path.empty()) {
+    std::cerr << "Usage: scan-file-cli [--host HOST] [--port PORT] <file>\n";
+    return 1;
+  }
+
+  try {
+    asio::io_context ioc;
+
+    tcp::resolver resolver{ioc};
+    auto const results = resolver.resolve(host, port);
+
+    websocket::stream<tcp::socket> ws{ioc};
+    asio::connect(ws.next_layer(), results);
+    ws.handshake(host, "/");
+
+    // Send ClientHello
+    medialode::ipc::ClientHello hello;
+    hello.token = "";
+    ws.write(asio::buffer(nlohmann::json(hello).dump()));
+
+    // Build ScanFileRequest
+    medialode::ipc::ScanFileRequest req;
+    req.request_id = "req1";
+    req.path = path;
+    ws.write(asio::buffer(nlohmann::json(req).dump()));
+
+    // Wait for response
+    beast::flat_buffer buffer;
+    ws.read(buffer);
+    std::string response = beast::buffers_to_string(buffer.data());
+    std::cout << response << "\n";
+
+    ws.close(websocket::close_code::normal);
+    return 0;
+  } catch (const std::exception& e) {
+    std::cerr << "Error: " << e.what() << "\n";
+    return 1;
+  }
+}
+

--- a/app/scan-folders-cli.cpp
+++ b/app/scan-folders-cli.cpp
@@ -1,4 +1,3 @@
-// app/scan-folders-cli.cpp
 #include <boost/asio.hpp>
 #include <boost/beast/core.hpp>
 #include <boost/beast/websocket.hpp>

--- a/app/scan-folders-cli.cpp
+++ b/app/scan-folders-cli.cpp
@@ -1,0 +1,77 @@
+// app/scan-folders-cli.cpp
+#include <boost/asio.hpp>
+#include <boost/beast/core.hpp>
+#include <boost/beast/websocket.hpp>
+#include <boost/beast/core/buffers_to_string.hpp>
+#include <iostream>
+#include <string>
+#include <vector>
+#include <nlohmann/json.hpp>
+#include "ipc/protocol.hpp"
+
+namespace asio = boost::asio;
+namespace beast = boost::beast;
+namespace websocket = beast::websocket;
+using tcp = asio::ip::tcp;
+
+int main(int argc, char* argv[]) {
+  // Defaults
+  std::string host = "127.0.0.1";
+  std::string port = "8081";
+  std::vector<std::string> paths;
+
+  // Tiny arg parser
+  for (int i = 1; i < argc; ++i) {
+    std::string a = argv[i];
+    if (a == "--host" && i + 1 < argc) { host = argv[++i]; }
+    else if (a == "--port" && i + 1 < argc) { port = argv[++i]; }
+    else if (a == "--help" || a == "-h") {
+      std::cout << "Usage: scan-folders-cli [--host HOST] [--port PORT] <folder1> [folder2 ...]\n";
+      return 0;
+    } else {
+      paths.push_back(a);
+    }
+  }
+
+  if (paths.empty()) {
+    std::cerr << "Usage: scan-folders-cli [--host HOST] [--port PORT] <folder1> [folder2 ...]\n";
+    return 1;
+  }
+
+  try {
+    asio::io_context ioc;
+
+    // Resolve and connect
+    tcp::resolver resolver{ioc};
+    auto const results = resolver.resolve(host, port);
+
+    websocket::stream<tcp::socket> ws{ioc};
+    asio::connect(ws.next_layer(), results);
+    ws.handshake(host, "/");
+
+    // Build request
+    medialode::ipc::ScanFoldersRequest req;
+    req.paths = paths;
+    nlohmann::json j = req;
+
+    // Send
+    ws.write(asio::buffer(j.dump()));
+
+    // Read response
+    beast::flat_buffer buffer;
+    ws.read(buffer);
+    std::string response = beast::buffers_to_string(buffer.data());
+    std::cout << response << "\n";
+
+    // Close
+    ws.close(websocket::close_code::normal);
+    return 0;
+  } catch (const beast::system_error& se) {
+    std::cerr << "Client error: " << se.code().message() << "\n";
+    return 1;
+  } catch (const std::exception& e) {
+    std::cerr << "Exception: " << e.what() << "\n";
+    return 1;
+  }
+}
+

--- a/docs/DB.md
+++ b/docs/DB.md
@@ -1,0 +1,26 @@
+# Database Schema
+
+The server (`libmgr-server`) maintains a SQLite database.
+
+## Pragmas
+- WAL mode enabled (`PRAGMA journal_mode = WAL`)
+- `synchronous = NORMAL`
+- Foreign keys enabled
+
+## Tables
+
+### folders
+| Column    | Type    | Notes                    |
+|-----------|---------|--------------------------|
+| path      | TEXT PK | Absolute path to folder |
+| last_scan | INTEGER | Epoch seconds            |
+
+### files
+| Column      | Type    | Notes                                    |
+|-------------|---------|------------------------------------------|
+| path        | TEXT PK | Absolute file path                       |
+| folder_path | TEXT    | Parent folder                            |
+| mtime       | INTEGER | Modification time (epoch seconds)        |
+
+Indexes:
+- `CREATE INDEX idx_files_folder ON files(folder_path);`

--- a/docs/ipc-spec.md
+++ b/docs/ipc-spec.md
@@ -1,0 +1,122 @@
+# IPC Protocol Specification
+
+## Overview
+
+The media library uses **JSON-over-WebSocket** for communication between clients and the server.
+All messages are sent as JSON objects with the following structure:
+
+`{  "type":  "<MessageType>",  "data":  { ... }  }`
+
+-   **type**: String identifying the message type.
+
+-   **data**: Object containing message-specific payload.
+
+
+----------
+
+## Message Types
+
+### 1. **PingRequest**
+
+**Purpose:** Check if the server is alive.
+
+**Direction:** Client → Server
+
+**Example:**
+
+`{  "type":  "PingRequest",  "data":  {  "message":  "ping"  }  }`
+
+----------
+
+### 2. **PingResponse**
+
+**Purpose:** Response to `PingRequest`.
+
+**Direction:** Server → Client
+
+**Example:**
+
+`{  "type":  "PingResponse",  "data":  {  "message":  "pong"  }  }`
+
+----------
+
+### 3. **ScanFoldersRequest**
+
+**Purpose:** Request the server to scan specific folders for media files.
+
+**Direction:** Client → Server
+
+**Fields:**
+
+-   `folders`: Array of strings (absolute paths to scan).
+
+
+**Example:**
+
+`{  "type":  "ScanFoldersRequest",  "data":  {  "folders":  [  "/home/user/Music",  "/home/user/Videos"  ]  }  }`
+
+----------
+
+### 4. **ScanFoldersResponse**
+
+**Purpose:** Acknowledgement that the scan has started.
+
+**Direction:** Server → Client
+
+**Fields:**
+
+-   `status`: String, one of:
+
+    -   `"ok"` (accepted)
+
+    -   `"error"` (invalid request)
+
+
+**Example:**
+
+`{  "type":  "ScanFoldersResponse",  "data":  {  "status":  "ok"  }  }`
+
+----------
+
+### 5. **ScanProgressEvent**
+
+**Purpose:** Notify the client about scan progress.
+
+**Direction:** Server → Client
+
+**Fields:**
+
+-   `folder`: String (the folder currently being scanned).
+
+-   `progress`: Integer (percentage, 0–100).
+
+
+**Example:**
+
+`{  "type":  "ScanProgressEvent",  "data":  {  "folder":  "/home/user/Music",  "progress":  42  }  }`
+
+----------
+
+## Connection Lifecycle
+
+1.  **Client connects** to `ws://<host>:<port>`.
+
+2.  **Server sends a greeting** (optional, currently skipped).
+
+3.  Client sends **PingRequest** or **ScanFoldersRequest**.
+
+4.  Server responds with corresponding message (`PingResponse`, `ScanFoldersResponse`) or emits **progress events**.
+
+5.  **Either party can close the connection** at any time.
+
+----------
+
+## Error Handling
+
+-   If a request is invalid, the server replies with:
+
+`{  "type":  "ErrorResponse",  "data":  {  "code":  "<ErrorCode>",  "message":  "<Error description>"  }  }`
+
+Example:
+
+`{  "type":  "ErrorResponse",  "data":  {  "code":  "INVALID_PAYLOAD",  "message":  "Missing 'folders' field in ScanFoldersRequest"  }  }`

--- a/docs/ipc-spec.md
+++ b/docs/ipc-spec.md
@@ -1,122 +1,123 @@
 # IPC Protocol Specification
 
-## Overview
+This document describes the JSON-over-WebSocket messages exchanged between:
 
-The media library uses **JSON-over-WebSocket** for communication between clients and the server.
-All messages are sent as JSON objects with the following structure:
+- **libmgr-server** (central database + orchestrator)
+- **libmgr-scan-worker** (scanner processes)
+- **CLI clients** (e.g. `scan-folders-cli`)
 
-`{  "type":  "<MessageType>",  "data":  { ... }  }`
+All messages are JSON objects with a required `"type"` field.
 
--   **type**: String identifying the message type.
+---
 
--   **data**: Object containing message-specific payload.
+## Ping
 
+- **PingRequest**
 
-----------
+```json
+{ "type": "PingRequest" }
+```
 
-## Message Types
+- **PingResponse**
+```json
+{ "type": "PingResponse", "message": "pong" }
+```
 
-### 1. **PingRequest**
+## Worker Identity
 
-**Purpose:** Check if the server is alive.
+- **WorkerHello**
 
-**Direction:** Client → Server
+Sent by workers on connect.
 
-**Example:**
+```json
+{
+  "type": "WorkerHello",
+  "role": "scan-worker",
+  "token": "changeme",
+  "name": "worker-1"
+}
+```
 
-`{  "type":  "PingRequest",  "data":  {  "message":  "ping"  }  }`
+## Fields:
 
-----------
+- role — currently "scan-worker".
 
-### 2. **PingResponse**
+- token — must match server’s LIBMGR_WORKER_TOKEN.
 
-**Purpose:** Response to `PingRequest`.
+- name — worker identifier (for logs).
 
-**Direction:** Server → Client
+## ClientHello
 
-**Example:**
+Sent optionally by CLI clients.
 
-`{  "type":  "PingResponse",  "data":  {  "message":  "pong"  }  }`
+```json
+{
+  "type": "ClientHello",
+  "token": ""
+}
+```
 
-----------
+## Folder Scan
 
-### 3. **ScanFoldersRequest**
+- **ScanFoldersRequest**
 
-**Purpose:** Request the server to scan specific folders for media files.
+Sent by clients.
 
-**Direction:** Client → Server
+```json
+{
+  "type": "ScanFoldersRequest",
+  "paths": ["/tmp", "/home/user/Music"]
+}
+```
 
-**Fields:**
+- **ScanFoldersResponse**
 
--   `folders`: Array of strings (absolute paths to scan).
+Reply from server after inserting into DB.
 
+```json
+{
+  "type": "ScanFoldersResponse",
+  "scanned_folders": 123,
+  "scanned_files": 4567
+}
+```
 
-**Example:**
+## File Scan
 
-`{  "type":  "ScanFoldersRequest",  "data":  {  "folders":  [  "/home/user/Music",  "/home/user/Videos"  ]  }  }`
+- **ScanFileRequest**
 
-----------
+Sent by server → worker.
 
-### 4. **ScanFoldersResponse**
+```json
+{
+  "type": "ScanFileRequest",
+  "request_id": "abcd123",
+  "path": "/tmp/example.wav"
+}
+```
+- **FileScanned**
 
-**Purpose:** Acknowledgement that the scan has started.
+Reply from worker.
 
-**Direction:** Server → Client
+```json
+{
+  "type": "FileScanned",
+  "request_id": "abcd123",
+  "path": "/tmp/example.wav",
+  "size": 102400,
+  "mtime": 1717776000
+}
+```
 
-**Fields:**
+- **FileError**
 
--   `status`: String, one of:
+Reply from worker on error.
 
-    -   `"ok"` (accepted)
-
-    -   `"error"` (invalid request)
-
-
-**Example:**
-
-`{  "type":  "ScanFoldersResponse",  "data":  {  "status":  "ok"  }  }`
-
-----------
-
-### 5. **ScanProgressEvent**
-
-**Purpose:** Notify the client about scan progress.
-
-**Direction:** Server → Client
-
-**Fields:**
-
--   `folder`: String (the folder currently being scanned).
-
--   `progress`: Integer (percentage, 0–100).
-
-
-**Example:**
-
-`{  "type":  "ScanProgressEvent",  "data":  {  "folder":  "/home/user/Music",  "progress":  42  }  }`
-
-----------
-
-## Connection Lifecycle
-
-1.  **Client connects** to `ws://<host>:<port>`.
-
-2.  **Server sends a greeting** (optional, currently skipped).
-
-3.  Client sends **PingRequest** or **ScanFoldersRequest**.
-
-4.  Server responds with corresponding message (`PingResponse`, `ScanFoldersResponse`) or emits **progress events**.
-
-5.  **Either party can close the connection** at any time.
-
-----------
-
-## Error Handling
-
--   If a request is invalid, the server replies with:
-
-`{  "type":  "ErrorResponse",  "data":  {  "code":  "<ErrorCode>",  "message":  "<Error description>"  }  }`
-
-Example:
-
-`{  "type":  "ErrorResponse",  "data":  {  "code":  "INVALID_PAYLOAD",  "message":  "Missing 'folders' field in ScanFoldersRequest"  }  }`
+```json
+{
+  "type": "FileError",
+  "request_id": "abcd123",
+  "path": "/tmp/missing.txt",
+  "error": "file not found"
+}
+```

--- a/include/medialode/file_watcher.hpp
+++ b/include/medialode/file_watcher.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+void test_llfio();

--- a/include/medialode/file_watcher.hpp
+++ b/include/medialode/file_watcher.hpp
@@ -1,3 +1,0 @@
-#pragma once
-
-void test_llfio();

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,11 +1,43 @@
+include(FetchContent)
+
+# OUTCOME
+FetchContent_Declare(
+  outcome
+  GIT_REPOSITORY https://github.com/ned14/outcome.git
+  GIT_TAG        744da6b7536f2850df972ab01504e3c4d9530149
+)
+FetchContent_MakeAvailable(outcome)
+
+# QUICKCPPLIB
+FetchContent_Declare(
+  quickcpplib
+  GIT_REPOSITORY https://github.com/ned14/quickcpplib.git
+  GIT_TAG        659f470cec041df6c7d74c5786d9c518dc42263e
+)
+FetchContent_MakeAvailable(quickcpplib)
+
+# LLFIO
+FetchContent_Declare(
+  llfio
+  GIT_REPOSITORY https://github.com/ned14/llfio.git
+  GIT_TAG        06ea607de0346a1d77a807fd37efc2fdfb005de5
+)
+FetchContent_MakeAvailable(llfio)
+
 add_library(medialode-lib
     scanlib.cpp
+    file_watcher.cpp
 )
 
 target_include_directories(medialode-lib
-    PUBLIC ${CMAKE_SOURCE_DIR}/include
+    PUBLIC
+        ${CMAKE_SOURCE_DIR}/include
+        ${llfio_SOURCE_DIR}/include
+        ${outcome_SOURCE_DIR}/include
+        ${quickcpplib_SOURCE_DIR}/include
 )
 
-# TODO: Add LLFIO, SQLite, Boost, etc. dependencies here
-# target_link_libraries(medialode-lib PRIVATE ...)
+target_link_libraries(medialode-lib
+    PUBLIC llfio_sl
+)
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -20,7 +20,7 @@ FetchContent_MakeAvailable(quickcpplib)
 FetchContent_Declare(
   llfio
   GIT_REPOSITORY https://github.com/ned14/llfio.git
-  GIT_TAG        af19b0da98b5b8c834a40a421a35b5a581e3e312
+  GIT_TAG        develop
 )
 FetchContent_MakeAvailable(llfio)
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -20,7 +20,7 @@ FetchContent_MakeAvailable(quickcpplib)
 FetchContent_Declare(
   llfio
   GIT_REPOSITORY https://github.com/ned14/llfio.git
-  GIT_TAG        06ea607de0346a1d77a807fd37efc2fdfb005de5
+  GIT_TAG        af19b0da98b5b8c834a40a421a35b5a581e3e312
 )
 FetchContent_MakeAvailable(llfio)
 
@@ -40,4 +40,3 @@ target_include_directories(medialode-lib
 target_link_libraries(medialode-lib
     PUBLIC llfio_sl
 )
-

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -16,14 +16,6 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(quickcpplib)
 
-# LLFIO
-FetchContent_Declare(
-  llfio
-  GIT_REPOSITORY https://github.com/ned14/llfio.git
-  GIT_TAG        develop
-)
-FetchContent_MakeAvailable(llfio)
-
 add_library(medialode-lib
     scanlib.cpp
     file_watcher.cpp
@@ -32,11 +24,9 @@ add_library(medialode-lib
 target_include_directories(medialode-lib
     PUBLIC
         ${CMAKE_SOURCE_DIR}/include
-        ${llfio_SOURCE_DIR}/include
         ${outcome_SOURCE_DIR}/include
         ${quickcpplib_SOURCE_DIR}/include
 )
 
 target_link_libraries(medialode-lib
-    PUBLIC llfio_sl
 )

--- a/lib/file_watcher.cpp
+++ b/lib/file_watcher.cpp
@@ -1,0 +1,27 @@
+#include <llfio/llfio.hpp>
+#include <iostream>
+#include <system_error>
+
+namespace llfio = LLFIO_V2_NAMESPACE;
+
+void test_llfio()
+{
+    try
+    {
+        auto result = llfio::temp_directory();
+        if (!result)
+        {
+            auto err = result.error();
+            std::cerr << "LLFIO error: " << err.message() << std::endl;
+            throw std::system_error(std::error_code(static_cast<int>(err.value()), std::generic_category()), "temp_directory() failed");
+        }
+
+        auto dir = std::move(result.value());
+        std::cout << "Temp directory handle obtained successfully.\n";
+    }
+
+    catch (const std::exception& e)
+    {
+        std::cerr << "Exception: " << e.what() << std::endl;
+    }
+}

--- a/lib/file_watcher.cpp
+++ b/lib/file_watcher.cpp
@@ -1,4 +1,4 @@
-#include <llfio/llfio.hpp>
+/* #include <llfio/llfio.hpp>
 #include <iostream>
 #include <system_error>
 
@@ -24,4 +24,4 @@ void test_llfio()
     {
         std::cerr << "Exception: " << e.what() << std::endl;
     }
-}
+}*/

--- a/lib/ipc/protocol.hpp
+++ b/lib/ipc/protocol.hpp
@@ -9,7 +9,7 @@ namespace medialode::ipc {
 
 using json = nlohmann::json;
 
-// -------- Existing --------
+// Existing
 struct PingRequest { std::string type = "PingRequest"; };
 struct PingResponse { std::string type = "PingResponse"; std::string message; };
 
@@ -20,7 +20,7 @@ struct ScanFoldersResponse {
   std::size_t scanned_files   = 0;
 };
 
-// -------- Worker/client identity & file scan --------
+// Worker/client identity & file scan
 struct WorkerHello {
   std::string type = "WorkerHello";
   std::string role = "scan-worker"; // default role
@@ -62,7 +62,7 @@ using IPCMessage = std::variant<
   ScanFileRequest, FileScanned, FileError
 >;
 
-// --- JSON ---
+// JSON
 
 // WorkerHello (merged definition)
 inline void to_json(nlohmann::json& j, const WorkerHello& m) {

--- a/lib/ipc/protocol.hpp
+++ b/lib/ipc/protocol.hpp
@@ -1,107 +1,147 @@
 #pragma once
-
 #include <nlohmann/json.hpp>
 #include <string>
-#include <variant>
 #include <vector>
+#include <variant>
+#include <cstdint>
 
 namespace medialode::ipc {
 
-// --- Message types --- //
-
-struct PingRequest {
-  std::string message = "ping";
-};
-
-struct PingResponse {
-  std::string message = "pong";
-};
-
-struct ScanFoldersRequest {
-  std::vector<std::string> folders;
-};
-
-struct ScanFoldersResponse {
-  bool success;
-  std::string error_message;
-};
-
-// --- JSON serialization --- //
-
 using json = nlohmann::json;
 
-inline void to_json(json& j, const PingRequest& msg) {
-  j = json{{"message", msg.message}};
-}
+// -------- Existing --------
+struct PingRequest { std::string type = "PingRequest"; };
+struct PingResponse { std::string type = "PingResponse"; std::string message; };
 
-inline void from_json(const json& j, PingRequest& msg) {
-  j.at("message").get_to(msg.message);
-}
-
-inline void to_json(json& j, const PingResponse& msg) {
-  j = json{{"message", msg.message}};
-}
-
-inline void from_json(const json& j, PingResponse& msg) {
-  j.at("message").get_to(msg.message);
-}
-
-inline void to_json(json& j, const ScanFoldersRequest& msg) {
-  j = json{{"folders", msg.folders}};
-}
-
-inline void from_json(const json& j, ScanFoldersRequest& msg) {
-  j.at("folders").get_to(msg.folders);
-}
-
-inline void to_json(json& j, const ScanFoldersResponse& msg) {
-  j = json{{"success", msg.success}, {"error_message", msg.error_message}};
-}
-
-inline void from_json(const json& j, ScanFoldersResponse& msg) {
-  j.at("success").get_to(msg.success);
-  j.at("error_message").get_to(msg.error_message);
-}
-
-// --- Envelope for polymorphic messages --- //
-
-using MessageVariant = std::variant<PingRequest, PingResponse, ScanFoldersRequest, ScanFoldersResponse>;
-
-struct MessageEnvelope {
-  std::string type;
-  json data;
+struct ScanFoldersRequest { std::string type = "ScanFoldersRequest"; std::vector<std::string> paths; };
+struct ScanFoldersResponse {
+  std::string type = "ScanFoldersResponse";
+  std::size_t scanned_folders = 0;
+  std::size_t scanned_files   = 0;
 };
 
-inline void to_json(json& j, const MessageEnvelope& env) {
-  j = json{{"type", env.type}, {"data", env.data}};
+// -------- Worker/client identity & file scan --------
+struct WorkerHello {
+  std::string type = "WorkerHello";
+  std::string role = "scan-worker"; // default role
+  std::string token;                // required by server
+  std::string name;                 // worker identifier
+};
+
+struct ClientHello {
+  std::string type = "ClientHello";
+  std::string token; // optional
+};
+
+struct ScanFileRequest {
+  std::string type = "ScanFileRequest";
+  std::string request_id;
+  std::string path;
+};
+
+struct FileScanned {
+  std::string type = "FileScanned";
+  std::string request_id;
+  std::string path;
+  std::uintmax_t size = 0;
+  std::int64_t   mtime = 0;
+};
+
+struct FileError {
+  std::string type = "FileError";
+  std::string request_id;
+  std::string path;
+  std::string error;
+};
+
+// Union
+using IPCMessage = std::variant<
+  PingRequest, PingResponse,
+  ScanFoldersRequest, ScanFoldersResponse,
+  WorkerHello, ClientHello,
+  ScanFileRequest, FileScanned, FileError
+>;
+
+// --- JSON ---
+
+// WorkerHello (merged definition)
+inline void to_json(nlohmann::json& j, const WorkerHello& m) {
+  j = nlohmann::json{
+    {"type", m.type},
+    {"role", m.role},
+    {"token", m.token},
+    {"name", m.name}
+  };
+}
+inline void from_json(const nlohmann::json& j, WorkerHello& m) {
+  m.role  = j.value("role", "scan-worker");
+  m.token = j.value("token", "");
+  m.name  = j.value("name", "");
 }
 
-inline void from_json(const json& j, MessageEnvelope& env) {
-  j.at("type").get_to(env.type);
-  j.at("data").get_to(env.data);
+inline void to_json(json& j, const PingRequest& m){ j = {{"type", m.type}}; }
+inline void from_json(const json&, PingRequest&){}
+
+inline void to_json(json& j, const PingResponse& m){ j = {{"type", m.type},{"message", m.message}}; }
+inline void from_json(const json& j, PingResponse& m){ m.message = j.at("message").get<std::string>(); }
+
+inline void to_json(json& j, const ScanFoldersRequest& m){ j = {{"type", m.type},{"paths", m.paths}}; }
+inline void from_json(const json& j, ScanFoldersRequest& m){ m.paths = j.at("paths").get<std::vector<std::string>>(); }
+
+inline void to_json(json& j, const ScanFoldersResponse& m){
+  j = {{"type", m.type},{"scanned_folders", m.scanned_folders},{"scanned_files", m.scanned_files}};
+}
+inline void from_json(const json& j, ScanFoldersResponse& m){
+  m.scanned_folders = j.at("scanned_folders").get<std::size_t>();
+  m.scanned_files   = j.at("scanned_files").get<std::size_t>();
 }
 
-inline MessageVariant parse_variant(const MessageEnvelope& env) {
-  if (env.type == "PingRequest") return env.data.get<PingRequest>();
-  if (env.type == "PingResponse") return env.data.get<PingResponse>();
-  if (env.type == "ScanFoldersRequest") return env.data.get<ScanFoldersRequest>();
-  if (env.type == "ScanFoldersResponse") return env.data.get<ScanFoldersResponse>();
-  throw std::runtime_error("Unknown message type: " + env.type);
+inline void to_json(json& j, const ClientHello& m){ j = {{"type", m.type},{"token", m.token}}; }
+inline void from_json(const json& j, ClientHello& m){ m.token = j.value("token",""); }
+
+inline void to_json(json& j, const ScanFileRequest& m){ j = {{"type", m.type},{"request_id", m.request_id},{"path", m.path}}; }
+inline void from_json(const json& j, ScanFileRequest& m){
+  m.request_id = j.at("request_id").get<std::string>();
+  m.path       = j.at("path").get<std::string>();
 }
 
-inline MessageEnvelope make_envelope(const MessageVariant& var) {
-  MessageEnvelope env;
-  std::visit([&](auto&& v) {
-    using T = std::decay_t<decltype(v)>;
-    env.type = typeid(T).name(); // fallback, will replace below
-    env.data = v;
-    if constexpr (std::is_same_v<T, PingRequest>) env.type = "PingRequest";
-    else if constexpr (std::is_same_v<T, PingResponse>) env.type = "PingResponse";
-    else if constexpr (std::is_same_v<T, ScanFoldersRequest>) env.type = "ScanFoldersRequest";
-    else if constexpr (std::is_same_v<T, ScanFoldersResponse>) env.type = "ScanFoldersResponse";
-  }, var);
-  return env;
+inline void to_json(json& j, const FileScanned& m){
+  j = {{"type", m.type},{"request_id", m.request_id},{"path", m.path},{"size", m.size},{"mtime", m.mtime}};
+}
+inline void from_json(const json& j, FileScanned& m){
+  m.request_id = j.at("request_id").get<std::string>();
+  m.path       = j.at("path").get<std::string>();
+  m.size       = j.at("size").get<std::uintmax_t>();
+  m.mtime      = j.at("mtime").get<std::int64_t>();
+}
+
+inline void to_json(json& j, const FileError& m){
+  j = {{"type", m.type},{"request_id", m.request_id},{"path", m.path},{"error", m.error}};
+}
+inline void from_json(const json& j, FileError& m){
+  m.request_id = j.at("request_id").get<std::string>();
+  m.path       = j.at("path").get<std::string>();
+  m.error      = j.at("error").get<std::string>();
+}
+
+// Parse helper
+inline IPCMessage parseMessage(const std::string& text){
+  auto j = json::parse(text);
+  auto t = j.at("type").get<std::string>();
+  if(t=="PingRequest") return j.get<PingRequest>();
+  if(t=="PingResponse") return j.get<PingResponse>();
+  if(t=="ScanFoldersRequest") return j.get<ScanFoldersRequest>();
+  if(t=="ScanFoldersResponse") return j.get<ScanFoldersResponse>();
+  if(t=="WorkerHello") return j.get<WorkerHello>();
+  if(t=="ClientHello") return j.get<ClientHello>();
+  if(t=="ScanFileRequest") return j.get<ScanFileRequest>();
+  if(t=="FileScanned") return j.get<FileScanned>();
+  if(t=="FileError") return j.get<FileError>();
+  throw std::runtime_error("Unknown message type: " + t);
+}
+
+inline std::string to_text(const IPCMessage& msg){
+  json j; std::visit([&](auto const& v){ j=v; }, msg); return j.dump();
 }
 
 } // namespace medialode::ipc
-

--- a/lib/ipc/protocol.hpp
+++ b/lib/ipc/protocol.hpp
@@ -1,0 +1,107 @@
+#pragma once
+
+#include <nlohmann/json.hpp>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace medialode::ipc {
+
+// --- Message types --- //
+
+struct PingRequest {
+  std::string message = "ping";
+};
+
+struct PingResponse {
+  std::string message = "pong";
+};
+
+struct ScanFoldersRequest {
+  std::vector<std::string> folders;
+};
+
+struct ScanFoldersResponse {
+  bool success;
+  std::string error_message;
+};
+
+// --- JSON serialization --- //
+
+using json = nlohmann::json;
+
+inline void to_json(json& j, const PingRequest& msg) {
+  j = json{{"message", msg.message}};
+}
+
+inline void from_json(const json& j, PingRequest& msg) {
+  j.at("message").get_to(msg.message);
+}
+
+inline void to_json(json& j, const PingResponse& msg) {
+  j = json{{"message", msg.message}};
+}
+
+inline void from_json(const json& j, PingResponse& msg) {
+  j.at("message").get_to(msg.message);
+}
+
+inline void to_json(json& j, const ScanFoldersRequest& msg) {
+  j = json{{"folders", msg.folders}};
+}
+
+inline void from_json(const json& j, ScanFoldersRequest& msg) {
+  j.at("folders").get_to(msg.folders);
+}
+
+inline void to_json(json& j, const ScanFoldersResponse& msg) {
+  j = json{{"success", msg.success}, {"error_message", msg.error_message}};
+}
+
+inline void from_json(const json& j, ScanFoldersResponse& msg) {
+  j.at("success").get_to(msg.success);
+  j.at("error_message").get_to(msg.error_message);
+}
+
+// --- Envelope for polymorphic messages --- //
+
+using MessageVariant = std::variant<PingRequest, PingResponse, ScanFoldersRequest, ScanFoldersResponse>;
+
+struct MessageEnvelope {
+  std::string type;
+  json data;
+};
+
+inline void to_json(json& j, const MessageEnvelope& env) {
+  j = json{{"type", env.type}, {"data", env.data}};
+}
+
+inline void from_json(const json& j, MessageEnvelope& env) {
+  j.at("type").get_to(env.type);
+  j.at("data").get_to(env.data);
+}
+
+inline MessageVariant parse_variant(const MessageEnvelope& env) {
+  if (env.type == "PingRequest") return env.data.get<PingRequest>();
+  if (env.type == "PingResponse") return env.data.get<PingResponse>();
+  if (env.type == "ScanFoldersRequest") return env.data.get<ScanFoldersRequest>();
+  if (env.type == "ScanFoldersResponse") return env.data.get<ScanFoldersResponse>();
+  throw std::runtime_error("Unknown message type: " + env.type);
+}
+
+inline MessageEnvelope make_envelope(const MessageVariant& var) {
+  MessageEnvelope env;
+  std::visit([&](auto&& v) {
+    using T = std::decay_t<decltype(v)>;
+    env.type = typeid(T).name(); // fallback, will replace below
+    env.data = v;
+    if constexpr (std::is_same_v<T, PingRequest>) env.type = "PingRequest";
+    else if constexpr (std::is_same_v<T, PingResponse>) env.type = "PingResponse";
+    else if constexpr (std::is_same_v<T, ScanFoldersRequest>) env.type = "ScanFoldersRequest";
+    else if constexpr (std::is_same_v<T, ScanFoldersResponse>) env.type = "ScanFoldersResponse";
+  }, var);
+  return env;
+}
+
+} // namespace medialode::ipc
+


### PR DESCRIPTION
# Summary

This PR implements steps 3–7 of the roadmap, covering the core IPC protocol, database server skeleton, folder scanning, WAL setup, and a generic scan worker process.

This PR introduces the first working implementation of the IPC protocol, the SQLite-backed server skeleton, and the generic scan worker. Earlier experimental branches (IPC, server-skeleton) have been superseded by this complete implementation.

# Changes

## Step 3: IPC Protocol

- Defined JSON-over-WebSocket message types (Ping, ScanFoldersRequest/Response, WorkerHello, ClientHello, ScanFileRequest, FileScanned, FileError).

- Added serialization/deserialization helpers in lib/ipc/protocol.hpp.


## Step 4: SQLite Server Skeleton

- Implemented libmgr-server binary.

- Listens on WebSocket (ws://localhost:8081).

- Responds to PingRequest with PingResponse.

## Step 5: Folder Scan Orchestration

- Added ScanFoldersRequest RPC.

- Recursively scans provided folders, persists results in DB.

## Step 6: WAL Mode & Schema

- Enabled PRAGMA journal_mode=WAL.

- Defined tables:

- folders (path, last_scan)

- files (path, folder_path, mtime)

## Step 7: Generic Scanner Worker

- Added libmgr-scan-worker binary.

- Connects to server and registers with WorkerHello.

- Handles ScanFileRequest and returns FileScanned or FileError.

- Added simple reconnection logic.

- Added scan-folders-cli to trigger scans from the command line.

# Documentation

- Added docs/ipc-spec.md (IPC API spec).

- Added docs/DB.md (database schema and WAL settings).

- Updated/added README.md with setup instructions, dependencies, and usage examples.

# Build

```
git clone git@github.com:ossia/medialode.git medialode
cd medialode
cmake -B build -DCMAKE_BUILD_TYPE=Release
cmake --build build -j
```

# How to Test

In separate terminals:

1. Run server:
```
./build/app/libmgr-server
```

2. Start worker:

The worker connects to the server and processes file scan requests.

Minimal usage (defaults to 127.0.0.1:8081):
```
./build/app/libmgr-scan-worker --name worker-1
```

You can also override the host/port:
```
./build/app/libmgr-scan-worker --host 127.0.0.1 --port 8081 --name worker-1
```

4. Run CLI:
```
./build/app/scan-folders-cli <path_to_directory>
```

# Delegation Test
```
./build/app/scan-file-cli --host 127.0.0.1 --port 8081 <path_to_file> 
```

This is to test that file delegation works.

`ScanFoldersRequest` will be refactored so that instead of the server doing all the recursion, it will:

- Break the folder into tasks (files or subfolders).

- Send those as ScanFileRequests to workers.

- Gather back FileScanned / FileError.

- Insert results into the DB.

# Next Steps

- Step 8: Implement image scanner worker.

- Step 9: Implement audio scanner worker.

- Step 10: Implement video scanner worker.